### PR TITLE
Add support for focused window (scrot)

### DIFF
--- a/mxfb-quickshot
+++ b/mxfb-quickshot
@@ -27,7 +27,7 @@ source ${HOME}/.config/MX-Linux/mxfb-quickshot.conf
 
 display_help() {
 	cat << EOF
-	Usage: `basename "$0"` [-r/r/-w/w/-b/b] [-png|png|-jpg|jpg] 
+	Usage: `basename "$0"` [-r/r/-w/w/-b/b/-u/u] [-png|png|-jpg|jpg]
 EOF
 }
 
@@ -55,17 +55,20 @@ then
 	exit 0
 else
 	case "$1" in
-		-r|r|-R|-r|root|Root|-root|-Root)
+		-r|r|-R|R|root|Root|-root|-Root)
 			OPTION=""
 			;;		
-		-w|w|-W|-W|window|Window|-window|-Window)
+		-w|w|-W|W|window|Window|-window|-Window)
 			OPTION="-s"
 			#PRE="part_"
 			;;
-		-b|b|-B|-B|border|Border)
+		-b|b|-B|B|border|Border|-border|-Border)
 			OPTION="-sb"
 			#PRE="part_"
 			;;		
+		-u|u|-U|U|focused|Focused|-focused|-Focused)
+			OPTION="-u"
+			;;
 		*)
 			display_help
 			exit 1


### PR DESCRIPTION
This change add support for the `-u`, `--focused` flag of scrot: **Use the currently focused window.**

With this change you can take a screenshot of the current active window using: `mxfb-quickshot -u -png` command. Check [this PR](https://github.com/MX-Linux/mx-fluxbox/pull/171) in which I added 2 `mxfb-quickshot` shortcuts.

With current workflow you need to press `Print` then click on the window and wait for the `mxfb-quickshot` window to close. With my recommended shortcut just press `Alt + Print`.

Also I made minor changes in the other options' flags.